### PR TITLE
build: update to tonic 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["grpc", "mock", "testing"]
 doctest = false
 
 [dependencies]
-tonic = { version = "0.12.3" }
+tonic = { version = "0.13.0" }
 rand = { version = "0.8.5" }
 prost = { version = "0.13.3" }
 tokio = { version = "1.41.1" }
@@ -22,7 +22,7 @@ http-body = { version = "1.0.1" }
 log = { version = "0.4.22" }
 
 [build-dependencies]
-tonic-build = { version = "0.12.3" }
+tonic-build = { version = "0.13.0" }
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/src/wiremock/codegen.rs
+++ b/src/wiremock/codegen.rs
@@ -65,7 +65,7 @@ macro_rules! generate {
             B: ::wiremock_grpc::http_body::Body + Send + 'static,
             B::Error: Into<tonic::codegen::StdError> + Send + 'static,
         {
-            type Response = tonic::codegen::http::Response<tonic::body::BoxBody>;
+            type Response = tonic::codegen::http::Response<tonic::body::Body>;
             type Error = std::convert::Infallible;
             type Future = tonic::codegen::BoxFuture<Self::Response, Self::Error>;
 

--- a/src/wiremock/grpc_server.rs
+++ b/src/wiremock/grpc_server.rs
@@ -166,7 +166,7 @@ impl GrpcServer {
     pub fn handle_request<B>(
         &self,
         req: http::Request<B>,
-    ) -> tonic::codegen::BoxFuture<http::Response<tonic::body::BoxBody>, std::convert::Infallible>
+    ) -> tonic::codegen::BoxFuture<http::Response<tonic::body::Body>, std::convert::Infallible>
     where
         B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
@@ -207,7 +207,7 @@ impl GrpcServer {
             info!("Returning empty body with status {}", status);
 
             return Box::pin(async move {
-                let body = builder.body(tonic::body::empty_body()).unwrap();
+                let body = builder.body(tonic::body::Body::default()).unwrap();
                 Ok(body)
             });
         }
@@ -219,7 +219,7 @@ impl GrpcServer {
             .header("grpc-status", format!("{}", Code::Unimplemented as u32));
 
         Box::pin(async move {
-            let body = builder.body(tonic::body::empty_body()).unwrap();
+            let body = builder.body(tonic::body::Body::empty()).unwrap();
             Ok(body)
         })
     }

--- a/tests/codegen_test.rs
+++ b/tests/codegen_test.rs
@@ -9,7 +9,7 @@ use wiremock_grpc::*;
 async fn codegen_works() {
     let server = Server::start_default().await;
 
-    assert!(std::net::TcpStream::connect(&server.address()).is_ok())
+    assert!(std::net::TcpStream::connect(server.address()).is_ok())
 }
 
 //
@@ -41,7 +41,7 @@ where
     B: http_body::Body + Send + 'static,
     B::Error: Into<tonic::codegen::StdError> + Send + 'static,
 {
-    type Response = tonic::codegen::http::Response<tonic::body::BoxBody>;
+    type Response = tonic::codegen::http::Response<tonic::body::Body>;
     type Error = std::convert::Infallible;
     type Future = tonic::codegen::BoxFuture<Self::Response, Self::Error>;
 
@@ -72,7 +72,7 @@ impl Server {
     }
 
     async fn start_internal(&mut self) -> Self {
-        let address = self.address().clone();
+        let address = *self.address();
         let thread = tokio::spawn(
             tonic::transport::Server::builder()
                 .add_service(self.clone())

--- a/tests/features_test.rs
+++ b/tests/features_test.rs
@@ -18,7 +18,7 @@ use wiremock_grpc::*;
 async fn it_starts_with_specified_port() {
     let server = MyMockServer::start(5055).await;
 
-    assert!(TcpStream::connect(&server.address()).is_ok())
+    assert!(TcpStream::connect(server.address()).is_ok());
 }
 
 #[tokio::test]
@@ -191,5 +191,5 @@ async fn create() -> (MyMockServer, GreeterClient<Channel>) {
             .connect()
             .await
             .unwrap();
-    return (server, GreeterClient::new(channel));
+    (server, GreeterClient::new(channel))
 }


### PR DESCRIPTION
We're using your crate for testing in production and we're currently blocked from updating dependencies on this. Would be nice to keep using what you built!